### PR TITLE
Use Paths annotation instead of Iterable[Path]

### DIFF
--- a/ndnt/arguments.py
+++ b/ndnt/arguments.py
@@ -2,17 +2,17 @@
 
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser
-from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Sequence
 
 from ndnt.extension import Extension
+from ndnt.paths import Paths
 
 
 class Arguments(ABC):
     """Ndnt arguments."""
 
     @abstractmethod
-    def paths(self) -> Iterable[Path]:
+    def paths(self) -> Paths:
         """Path to inspect."""
 
     @abstractmethod
@@ -31,7 +31,7 @@ class CliArguments(Arguments):
         self.args = args
         self.cli = cli
 
-    def paths(self) -> Iterable[Path]:
+    def paths(self) -> Paths:
         """Path for CLI."""
         return self.cli.parse_args(self.args).paths
 

--- a/ndnt/lines.py
+++ b/ndnt/lines.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Iterable
 
 from ndnt.line import Line
+from ndnt.paths import Paths
 
 
 class Lines(Iterable[Line]):
@@ -57,7 +58,7 @@ class CombinedLines(Lines):
 class LinesFromFiles(Lines):
     """Lines from multiple files as one `Lines`."""
 
-    def __init__(self, paths: Iterable[Path]):
+    def __init__(self, paths: Paths):
         self.paths = paths
 
     def __iter__(self) -> Iterable[Line]:

--- a/ndnt/summary.py
+++ b/ndnt/summary.py
@@ -2,10 +2,10 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Iterable
 
 from ndnt.indent import AverageIndent, RoundedAverageIndent
 from ndnt.lines import LinesFromFile, LinesFromFiles, NonBlankLines
+from ndnt.paths import Paths
 
 
 class Summary(ABC):
@@ -41,7 +41,7 @@ class FilesSummary(Summary):
     Shows average indent of multiple files.
     """
 
-    def __init__(self, paths: Iterable[Path]):
+    def __init__(self, paths: Paths):
         self.paths = paths
 
     def print(self):
@@ -58,7 +58,7 @@ class DirectorySummary(Summary):
     average indent of all files combined.
     """
 
-    def __init__(self, paths: Iterable[Path]):
+    def __init__(self, paths: Paths):
         self.paths = paths
 
     def print(self):

--- a/tests/test_ndnts.py
+++ b/tests/test_ndnts.py
@@ -1,25 +1,23 @@
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Iterable
 
 from ndnt.arguments import Arguments
 from ndnt.extension import Extension
 from ndnt.ndnt import Ndnts
+from ndnt.paths import Paths
 from ndnt.summary import FileSummary
 
 
 class FakeArguments(Arguments):
     """Fake class to mock arguments."""
 
-    def __init__(
-        self, paths: Iterable[Path], extension: Extension, no_gitignore: bool
-    ):
+    def __init__(self, paths: Paths, extension: Extension, no_gitignore: bool):
         self._paths = paths
         self._extension = extension
         self._no_gitignore = no_gitignore
 
-    def paths(self) -> Iterable[Path]:
+    def paths(self) -> Paths:
         return self._paths
 
     def extension(self) -> Extension:


### PR DESCRIPTION
Closes #18.

## Checklist

- [x] I reference related Issue.
- [ ] I update CHANGELOG (if needed).

## Goals

- [x] Replace Iterable[Path] annotations with Paths
